### PR TITLE
Add Zip export option in the context menu of the table

### DIFF
--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -215,12 +215,17 @@ export default {
     /**
      * Export records as .txt into compressed .zip file
      */
-    exporZipRecordTable() {
+    exporZipRecordTable({
+      recordContexMenu = false
+    }) {
       const header = this.getterFieldsListHeader
       const filterVal = this.getterFieldsListValue
       let list = this.getDataSelection
       if (this.getDataSelection.length <= 0) {
         list = this.recordsData
+      }
+      if (recordContexMenu) {
+        list = [this.currentRow]
       }
       const data = this.formatJson(filterVal, list)
 

--- a/src/components/ADempiere/DataTable/menu/tableContextMenu.vue
+++ b/src/components/ADempiere/DataTable/menu/tableContextMenu.vue
@@ -19,6 +19,13 @@
       </el-menu-item>
     </el-submenu>
     <el-menu-item
+      @click="exporZipRecordTable({
+        recordContexMenu: true
+      })"
+    >
+      {{ $t('table.dataTable.exportZip') }}
+    </el-menu-item>
+    <el-menu-item
       v-if="panelType === 'window'"
       index="delete"
       @click="deleteRecord()"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Added the option to export Zip file individually in the context menu of the table.
#### Steps to reproduce

1. Go to a table
2. Open the context menu (right click)
3. Export Zip

#### Screenshot or Gif
![addOptionintable](https://user-images.githubusercontent.com/45974454/110963599-a67be500-8328-11eb-970d-16ce70ae9834.gif)


#### Link to minimal reproduction

https://demo-ui.erpya.com/#/a48d2596-fb40-11e8-a479-7a0060f0aa01/a3e5c878-fb40-11e8-a479-7a0060f0aa01/window/53228?tabParent=0&tabChild=1&action=a4cb51ea-fb40-11e8-a479-7a0060f0aa01

#### Other relevant information
- Your OS: Debian9
- Web Browser: Mozilla Firefox 85.0.
- Node.js version: 12.20.0.
- Adempiere-vue version: 4.3.1.
